### PR TITLE
Params standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ allowing for common functionality like authentication and logging to be shared
 across multiple routes.
 
 ### Note From Author:
-muxer has been in production at my company for over a year, coming up on two and 
+muxer has been in production at my company for over a year, coming up on two and
 is used in all of our microservices that power our backend service layer across
 kubernetes, cloud foundry and aws. It is my hope it brings you joy in your programming!
 
@@ -168,6 +168,30 @@ This pattern can be adjusted to suit different needs, including serving files fr
 Remember to replace /path/to/your/static/files with the actual path to the directory that contains your static files.
 
 Please note that it's always a good practice to handle any errors that may occur during the setup and usage of http.FileServer. This includes checking if the specified directory exists and is readable, and handling any errors returned by fs.ServeHTTP
+
+## Working with Params
+
+In routes that include path parameters, such as `PUT /users/:id` and `DELETE /users/:id`, you need to extract these parameters from the request context. The `muxer` package provides a standalone `Params` function that makes this easy:
+
+```go
+func updateUserHandler(w http.ResponseWriter, req *http.Request) {
+    params := muxer.Params(req)
+    id := params["id"]
+
+    // Use the id to update the user
+    fmt.Printf("Updating user with ID: %s\n", id)
+}
+
+func deleteUserHandler(w http.ResponseWriter, req *http.Request) {
+    params := muxer.Params(req)
+    id := params["id"]
+
+    // Use the id to delete the user
+    fmt.Printf("Deleting user with ID: %s\n", id)
+}
+```
+
+By using the `Params` function, you can easily access the path parameters directly from the request context.
 
 ---
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -33,7 +33,7 @@ func BenchmarkRouter(b *testing.B) {
 	})
 
 	// Create a new request for the benchmark
-	//req := httptest.NewRequest(http.MethodGet, "/users/123", nil)
+	// req := httptest.NewRequest(http.MethodGet, "/users/123", nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/widgets/123/parts/456/update", nil)
 
 	// Create a new recorder for the benchmark

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,7 +53,6 @@ func main() {
 	if err := http.ListenAndServe(":8080", router); err != nil {
 		log.Fatal(err)
 	}
-
 }
 
 func logRequest(next http.Handler) http.Handler {

--- a/router.go
+++ b/router.go
@@ -235,6 +235,15 @@ It extracts the parameters from the request context, returns an empty map if
 there are no parameters found.
 */
 func (r *Router) Params(req *http.Request) map[string]string {
+	return Params(req)
+}
+
+/*
+Params returns the parameter names and values extracted from the request path.
+It extracts the parameters from the request context, returns an empty map if
+there are no parameters found.
+*/
+func Params(req *http.Request) map[string]string {
 	params := req.Context().Value(paramsKey)
 	if p, ok := params.(map[string]string); ok {
 		return p

--- a/router_test.go
+++ b/router_test.go
@@ -326,7 +326,6 @@ func TestNotFoundHandler(t *testing.T) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-
 	})
 	router.HandleRoute(http.MethodGet, "/users/:id", handlerFunc)
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request to Muxer :) -->

## Changes proposed by this PR

closes #1  <!-- replace with actual issue number or remove if no existing issue -->

<!--
  Summarize your changes as a checklist, leaving any unfinished work as unchecked
  items. Please include reasoning and key decisions to help the reviewer
  understand the changes.
-->

* [x] Introduce a standalone `Params` function to allow extraction of URL parameters directly from the request context.
* [x] Modify the `Router` type's `Params` method to use the new standalone `Params` function, ensuring backward compatibility.
* [x] Update documentation and tutorial to include instructions on working with the new `Params` function.

## Notes to reviewer

<!--
  If needed, leave any special pointers for reviewing or testing your PR.
-->

The new `Params` function improves the flexibility of the package by allowing clients to extract parameters without requiring an instance of the `Router` type. This change should not affect existing functionality, as the `Router` type's `Params` method now calls the standalone `Params` function internally.
