### PR TITLE
Export the previously unexported `paramsKey` as `ParamsKey` to allow

### DIFF
--- a/router.go
+++ b/router.go
@@ -10,7 +10,8 @@ import (
 type contextKey string
 
 const (
-	paramsKey contextKey = "params"
+	// ParamsKey is the key used to store the extracted parameters in the request context.
+	ParamsKey contextKey = "params"
 )
 
 /*
@@ -210,7 +211,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 
 		ctx := req.Context()
-		ctx = context.WithValue(ctx, paramsKey, params)
+		ctx = context.WithValue(ctx, ParamsKey, params)
 
 		handler := route.handler
 		for i := len(r.middleware) - 1; i >= 0; i-- {
@@ -244,7 +245,7 @@ It extracts the parameters from the request context, returns an empty map if
 there are no parameters found.
 */
 func Params(req *http.Request) map[string]string {
-	params := req.Context().Value(paramsKey)
+	params := req.Context().Value(ParamsKey)
 	if p, ok := params.(map[string]string); ok {
 		return p
 	}

--- a/router_test.go
+++ b/router_test.go
@@ -118,7 +118,7 @@ func TestParams(t *testing.T) {
 
 		// Set params in context
 		if len(tc.params) > 0 {
-			ctx := context.WithValue(req.Context(), paramsKey, tc.params)
+			ctx := context.WithValue(req.Context(), ParamsKey, tc.params)
 			req = req.WithContext(ctx)
 		}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request to Muxer :) -->

## Changes proposed by this PR

closes #2 <!-- replace with actual issue number or remove if no existing issue -->

<!--
  Summarize your changes as a checklist, leaving any unfinished work as unchecked
  items. Please include reasoning and key decisions to help the reviewer
  understand the changes.
-->

* [x] Export `paramsKey` as `ParamsKey` to allow direct context access for parameters.
* [x] Update documentation to reflect the new usage.

## Notes to reviewer

<!--
  If needed, leave any special pointers for reviewing or testing your PR.
-->

This PR exports the previously unexported `paramsKey` as `ParamsKey`. This change allows developers to directly access parameters stored in the request context, enhancing the flexibility of the `muxer` package. The `Params` function can still be used, but direct context access provides an additional method for parameter extraction.
