### PR TITLE
Add the ability to store and retrieve the path template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,3 @@
 module github.com/shellfu/muxer
 
 go 1.18
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/shellfu/muxer
 
 go 1.18
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/route.go
+++ b/route.go
@@ -1,6 +1,7 @@
 package muxer
 
 import (
+	"errors"
 	"net/http"
 	"regexp"
 )
@@ -11,10 +12,11 @@ It contains the regular expression that matches the request path, the HTTP metho
 the handler to be executed for that request, and the parameter names extracted from the path.
 */
 type Route struct {
-	path    *regexp.Regexp
-	method  string
-	handler http.Handler
-	params  []string
+	path     *regexp.Regexp
+	method   string
+	handler  http.Handler
+	params   []string
+	template string
 }
 
 func (r *Route) match(path string) map[string]string {
@@ -29,4 +31,17 @@ func (r *Route) match(path string) map[string]string {
 	}
 
 	return params
+}
+
+// PathTemplate retrieves the path template of the current route
+func (r *Route) PathTemplate() (string, error) {
+	if r == nil {
+		return "", errors.New("route is nil, no template")
+	}
+
+	if r.template == "" {
+		return r.template, errors.New("template is empty")
+	}
+
+	return r.template, nil
 }

--- a/router.go
+++ b/router.go
@@ -12,8 +12,8 @@ type contextKey string
 const (
 	// ParamsKey is the key used to store the extracted parameters in the request context.
 	ParamsKey contextKey = "params"
-	// routeContextKey is the key used to store the matched route in the request context
-	routeContextKey contextKey = "matched_route"
+	// RouteContextKey is the key used to store the matched route in the request context
+	RouteContextKey contextKey = "matched_route"
 )
 
 /*
@@ -211,7 +211,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		ctx := req.Context()
 		ctx = context.WithValue(ctx, ParamsKey, params)
-		ctx = context.WithValue(ctx, routeContextKey, &route)
+		ctx = context.WithValue(ctx, RouteContextKey, &route)
 
 		handler := route.handler
 		for i := len(r.middleware) - 1; i >= 0; i-- {
@@ -261,10 +261,13 @@ func (r *Router) Use(middleware ...func(http.Handler) http.Handler) {
 	r.middleware = append(r.middleware, middleware...)
 }
 
-// GetPathTemplate retrieves the path template of the current route from the current request context.
-func GetPathTemplate(req *http.Request) string {
-	if route, ok := req.Context().Value(routeContextKey).(*Route); ok {
-		return route.template
+// CurrentRoute returns the matched route for the current request, if any.
+// This only works when called inside the handler of the matched route
+// because the matched route is stored inside the request's context,
+// which is wiped after the handler returns.
+func CurrentRoute(r *http.Request) *Route {
+	if rv := r.Context().Value(RouteContextKey); rv != nil {
+		return rv.(*Route)
 	}
-	return "not_found"
+	return nil
 }

--- a/router.go
+++ b/router.go
@@ -12,6 +12,8 @@ type contextKey string
 const (
 	// ParamsKey is the key used to store the extracted parameters in the request context.
 	ParamsKey contextKey = "params"
+	// routeContextKey is the key used to store the matched route in the request context
+	routeContextKey contextKey = "matched_route"
 )
 
 /*
@@ -131,19 +133,20 @@ func (r *Router) HandleRoute(method, path string, handler http.HandlerFunc) {
 	// Parse path to extract parameter names
 	paramNames := make([]string, 0)
 	re := regexp.MustCompile(`:([\w-]+)`)
-	path = re.ReplaceAllStringFunc(path, func(m string) string {
+	pathRegex := re.ReplaceAllStringFunc(path, func(m string) string {
 		paramName := m[1:]
 		paramNames = append(paramNames, paramName)
 		return `([-\w.]+)`
 	})
 
-	exactPath := regexp.MustCompile("^" + path + "$")
+	exactPath := regexp.MustCompile("^" + pathRegex + "$")
 
 	r.routes = append(r.routes, Route{
-		method:  method,
-		path:    exactPath,
-		handler: handler,
-		params:  paramNames,
+		method:   method,
+		path:     exactPath,
+		handler:  handler,
+		params:   paramNames,
+		template: path, // Save the original template
 	})
 }
 
@@ -208,6 +211,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		ctx := req.Context()
 		ctx = context.WithValue(ctx, ParamsKey, params)
+		ctx = context.WithValue(ctx, routeContextKey, &route)
 
 		handler := route.handler
 		for i := len(r.middleware) - 1; i >= 0; i-- {
@@ -255,4 +259,12 @@ the given order before executing the main handler.
 */
 func (r *Router) Use(middleware ...func(http.Handler) http.Handler) {
 	r.middleware = append(r.middleware, middleware...)
+}
+
+// GetPathTemplate retrieves the path template of the current route from the current request context.
+func GetPathTemplate(req *http.Request) string {
+	if route, ok := req.Context().Value(routeContextKey).(*Route); ok {
+		return route.template
+	}
+	return "not_found"
 }

--- a/router.go
+++ b/router.go
@@ -146,7 +146,7 @@ func (r *Router) HandleRoute(method, path string, handler http.HandlerFunc) {
 		path:     exactPath,
 		handler:  handler,
 		params:   paramNames,
-		template: path, // Save the original template
+		template: path,
 	})
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request to Muxer :) -->

## Changes proposed by this PR
Adds a template field to the `Route` object which stores the initial template prior to the regex being applied. This is useful for documentation or metrics purposes to extract the template instead of the full route path. For example, a route with the template `/users/:id` can have this template retrieved when a request to `/users/123` is sent.

closes # <!-- remove if no existing issue -->

<!--
  Summarize your changes as a checklist, leaving any unfinished work as unchecked
  items. Please include reasoning and key decisions to help the reviewer
  understand the changes.
-->

* [x] Added template field to `Route` struct
* [x] Added CurrentRoute() and PathTemplate() functions
* [x] Add unit tests to maintain 100% code coverage

## Notes to reviewer

<!--
  If needed, leave any special pointers for reviewing or testing your PR.
-->
